### PR TITLE
Add NT Hash option

### DIFF
--- a/crackhound.py
+++ b/crackhound.py
@@ -53,7 +53,6 @@ def parse_compromised_users(file, type):
                     compromised_user = line
                 user_dict["username"] = compromised_user
                 compromised_users.append(user_dict)
-
             elif type.upper() == "NTDS":
                 if ":" in line:
                     split = line.split(":")


### PR DESCRIPTION
This allows the user to specify an NTDS dump instead of a cracked password file with the '-t' option. This adds an nthash field to each object and their NT Hash value. Useful for having instant access to the hash of a user for PtH, and will also allow for queries that can match accounts with shared passwords, even if you couldn't crack them.

This probably needs to be cleaned up a bit and tested more before merging to main, but just wanted to throw the idea out there.